### PR TITLE
Doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ I consider it to be in stable, perhaps even production, shape. There are no know
 
 ## Installation
 
-With a healthy Go Language installed, simply run `goinstall github.com/petar/GoLLRB/llrb`
+With a healthy Go Language installed, simply run `go get github.com/petar/GoLLRB/llrb`
 
 ## Example
     


### PR DESCRIPTION
`goinstall` no longer exists, so I changed the installation instructions to say `go get` instead.
