### PR TITLE
Add basic copy-on-write implementation

### DIFF
--- a/llrb/llrb.go
+++ b/llrb/llrb.go
@@ -19,6 +19,7 @@ package llrb
 // Tree is a Left-Leaning Red-Black (LLRB) implementation of 2-3 trees
 type LLRB struct {
 	count int
+	cow   bool
 	root  *Node
 }
 
@@ -76,6 +77,15 @@ func (pInf) Less(Item) bool {
 // New() allocates a new tree
 func New() *LLRB {
 	return &LLRB{}
+}
+
+func NewCoW() *LLRB {
+	return &LLRB{cow: true}
+}
+
+func (t *LLRB) Clone() *LLRB {
+	ret := *t
+	return &ret
 }
 
 // SetRoot sets the root node of the tree.
@@ -170,7 +180,7 @@ func (t *LLRB) replaceOrInsert(h *Node, item Item) (*Node, Item) {
 		return newNode(item), nil
 	}
 
-	h = walkDownRot23(h)
+	h = t.walkDownRot23(h)
 
 	var replaced Item
 	if less(item, h.Item) { // BUG
@@ -202,7 +212,7 @@ func (t *LLRB) insertNoReplace(h *Node, item Item) *Node {
 		return newNode(item)
 	}
 
-	h = walkDownRot23(h)
+	h = t.walkDownRot23(h)
 
 	if less(item, h.Item) {
 		h.Left = t.insertNoReplace(h.Left, item)
@@ -215,7 +225,13 @@ func (t *LLRB) insertNoReplace(h *Node, item Item) *Node {
 
 // Rotation driver routines for 2-3 algorithm
 
-func walkDownRot23(h *Node) *Node { return h }
+func (t *LLRB) walkDownRot23(h *Node) *Node {
+	if t.cow {
+		ret := *h
+		return &ret
+	}
+	return h
+}
 
 func walkUpRot23(h *Node) *Node {
 	if isRed(h.Right) && !isRed(h.Left) {

--- a/llrb/llrb.go
+++ b/llrb/llrb.go
@@ -30,6 +30,11 @@ type Node struct {
 	// In the LLRB, new nodes are always red, hence the zero-value for node
 }
 
+func (n *Node) Copy() *Node {
+	ret := *n
+	return &ret
+}
+
 type Item interface {
 	Less(than Item) bool
 }
@@ -180,8 +185,7 @@ func (t *LLRB) replaceOrInsert(h *Node, item Item) (*Node, Item) {
 		return newNode(item), nil
 	}
 	if t.cow {
-		newH := *h
-		h = &newH
+		h = h.Copy()
 	}
 
 	h = walkDownRot23(h)
@@ -216,8 +220,7 @@ func (t *LLRB) insertNoReplace(h *Node, item Item) *Node {
 		return newNode(item)
 	}
 	if t.cow {
-		newH := *h
-		h = &newH
+		h = h.Copy()
 	}
 
 	h = walkDownRot23(h)
@@ -297,8 +300,7 @@ func deleteMin(h *Node, cow bool) (*Node, Item) {
 	}
 
 	if cow {
-		newH := *h
-		h = &newH
+		h = h.Copy()
 	}
 
 	if !isRed(h.Left) && !isRed(h.Left.Left) {
@@ -330,8 +332,7 @@ func deleteMax(h *Node, cow bool) (*Node, Item) {
 		return nil, nil
 	}
 	if cow {
-		newH := *h
-		h = &newH
+		h = h.Copy()
 	}
 	if isRed(h.Left) {
 		h = rotateRight(h)
@@ -372,8 +373,7 @@ func (t *LLRB) delete(h *Node, item Item) (*Node, Item) {
 			return h, nil
 		}
 		if t.cow {
-			newH := *h
-			*h = newH
+			h = h.Copy()
 		}
 		if !isRed(h.Left) && !isRed(h.Left.Left) {
 			h = moveRedLeft(h)
@@ -381,8 +381,7 @@ func (t *LLRB) delete(h *Node, item Item) (*Node, Item) {
 		h.Left, deleted = t.delete(h.Left, item)
 	} else {
 		if t.cow {
-			newH := *h
-			*h = newH
+			h = h.Copy()
 		}
 		if isRed(h.Left) {
 			h = rotateRight(h)

--- a/llrb/llrb_test.go
+++ b/llrb/llrb_test.go
@@ -237,3 +237,33 @@ func TestInsertNoReplace(t *testing.T) {
 		return true
 	})
 }
+
+func TestCoW(t *testing.T) {
+	tree := NewCoW()
+	tree.InsertNoReplace(Int(4))
+	tree.InsertNoReplace(Int(6))
+	tree.InsertNoReplace(Int(1))
+	tree.InsertNoReplace(Int(3))
+
+	tree2 := tree.Clone()
+	tree.InsertNoReplace(Int(60))
+	orig := tree.ReplaceOrInsert(Int(4))
+
+	if tree2.Len() != 4 {
+		t.Errorf("Expected Len of 4, but got %d", tree2.Len())
+	}
+	if tree2.Get(Int(60)) != nil {
+		t.Errorf("Expected to get nil for 60")
+	}
+	if tree2.Get(Int(4)) != orig {
+		t.Errorf("Expected to get original for 4")
+	}
+
+	tree2.InsertNoReplace(Int(20))
+	if tree.Len() != 5 {
+		t.Errorf("Expected Len of 5, but got %d", tree.Len())
+	}
+	if tree.Get(Int(20)) != nil {
+		t.Errorf("Expected to get nil for 20")
+	}
+}

--- a/llrb/llrb_test.go
+++ b/llrb/llrb_test.go
@@ -287,7 +287,7 @@ func TestCoW(t *testing.T) {
 	})
 
 	i = 0
-	expect = []Int{3, 4, 6, 20}
+	expect = []Int{1, 3, 4, 6, 20}
 	tree2.AscendRange(Int(-1), Int(100), func(itm Item) bool {
 		iv := itm.(Int)
 		if iv != expect[i] {

--- a/llrb/llrb_test.go
+++ b/llrb/llrb_test.go
@@ -266,4 +266,34 @@ func TestCoW(t *testing.T) {
 	if tree.Get(Int(20)) != nil {
 		t.Errorf("Expected to get nil for 20")
 	}
+
+	orig = tree.Delete(Int(6))
+	tree.Delete(Int(1))
+	tree.DeleteMax()
+	tree.DeleteMin()
+	if tree2.Get(Int(6)) != orig {
+		t.Errorf("Expected to get original for 6")
+	}
+
+	i := 0
+	expect := []Int{4, 60}
+	tree.AscendRange(Int(-1), Int(100), func(itm Item) bool {
+		iv := itm.(Int)
+		if iv != expect[i] {
+			t.Errorf("expected %d got %d", expect[i], iv)
+		}
+		i++
+		return true
+	})
+
+	i = 0
+	expect = []Int{3, 4, 6, 20}
+	tree2.AscendRange(Int(-1), Int(100), func(itm Item) bool {
+		iv := itm.(Int)
+		if iv != expect[i] {
+			t.Errorf("expected %d got %d", expect[i], iv)
+		}
+		i++
+		return true
+	})
 }


### PR DESCRIPTION
This allows llrb to provide snapshotting (at the cost of reduced performance when in copy-on-write mode). No substantial performance impact on non-cow implementation.