### PR TITLE
fix AscendLessThan so it actually performs as expected and add comment

### DIFF
--- a/llrb/iterator.go
+++ b/llrb/iterator.go
@@ -64,10 +64,10 @@ func (t *LLRB) ascendLessThan(h *Node, pivot Item, iterator ItemIterator) bool {
 	if !t.ascendLessThan(h.Left, pivot, iterator) {
 		return false
 	}
-	if !iterator(h.Item) {
-		return false
-	}
 	if less(h.Item, pivot) {
+		if !iterator(h.Item) {
+			return false
+		}
 		return t.ascendLessThan(h.Right, pivot, iterator)
 	}
 	return true

--- a/llrb/iterator.go
+++ b/llrb/iterator.go
@@ -51,6 +51,8 @@ func (t *LLRB) ascendGreaterOrEqual(h *Node, pivot Item, iterator ItemIterator) 
 	return t.ascendGreaterOrEqual(h.Right, pivot, iterator)
 }
 
+// AscendLessThan will call iterator once for each element lower than
+// pivot in ascending order. It will stop whenever the iterator returns false.
 func (t *LLRB) AscendLessThan(pivot Item, iterator ItemIterator) {
 	t.ascendLessThan(t.root, pivot, iterator)
 }
@@ -66,7 +68,7 @@ func (t *LLRB) ascendLessThan(h *Node, pivot Item, iterator ItemIterator) bool {
 		return false
 	}
 	if less(h.Item, pivot) {
-		return t.ascendLessThan(h.Left, pivot, iterator)
+		return t.ascendLessThan(h.Right, pivot, iterator)
 	}
 	return true
 }

--- a/llrb/iterator_test.go
+++ b/llrb/iterator_test.go
@@ -74,3 +74,38 @@ func TestDescendLessOrEqual(t *testing.T) {
 		t.Errorf("expected %v but got %v", expected, ary)
 	}
 }
+
+func TestAscendLessThan(t *testing.T) {
+	tree := New()
+	tree.InsertNoReplace(Int(4))
+	tree.InsertNoReplace(Int(6))
+	tree.InsertNoReplace(Int(1))
+	tree.InsertNoReplace(Int(3))
+	var ary []Item
+	tree.AscendLessThan(Int(10), func(i Item) bool {
+		ary = append(ary, i)
+		return true
+	})
+	expected := []Item{Int(1), Int(3), Int(4), Int(6)}
+	if !reflect.DeepEqual(ary, expected) {
+		t.Errorf("expected %v but got %v", expected, ary)
+	}
+	ary = nil
+	tree.AscendLessThan(Int(4), func(i Item) bool {
+		ary = append(ary, i)
+		return true
+	})
+	expected = []Item{Int(1), Int(3)}
+	if !reflect.DeepEqual(ary, expected) {
+		t.Errorf("expected %v but got %v", expected, ary)
+	}
+	ary = nil
+	tree.AscendLessThan(Int(5), func(i Item) bool {
+		ary = append(ary, i)
+		return true
+	})
+	expected = []Item{Int(1), Int(3), Int(4)}
+	if !reflect.DeepEqual(ary, expected) {
+		t.Errorf("expected %v but got %v", expected, ary)
+	}
+}


### PR DESCRIPTION
Currently AscendLessThan doesn't work as expected, probably because of a wrong copy/paste where it is called recursively twice on Left.